### PR TITLE
Add retryWhen hook

### DIFF
--- a/lib/http-error.js
+++ b/lib/http-error.js
@@ -1,0 +1,22 @@
+module.exports = class HttpError extends Error {
+  constructor (message, statusCode, headers, request) {
+    super(message)
+
+    // Maintains proper stack trace (only available on V8)
+    /* istanbul ignore next */
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor)
+    };
+
+    this.name = 'HttpError'
+    this.status = statusCode
+    Object.defineProperty(this, 'code', {
+      get () {
+        console.warn('`error.code` is deprecated, use `error.status`.')
+        return statusCode
+      }
+    })
+    this.headers = headers
+    this.request = request
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,5 +116,23 @@ function throttlingPlugin (octokit, octokitOptions = {}) {
     }
   })
 
+	// after every request check if custom condition to retry request is met
+	// throw if it is to kick in retry limiter
+	octokit.hook.after('request', (response, options) => {
+	  if (!state.retryWhen) {
+	    return
+	  }
+
+	  const shouldRetry = state.retryWhen(response, options)
+
+	  if (shouldRetry) {
+	    throw new HttpError(
+	      response.statusText,
+	      response.status,
+	      response.headers,
+	    )
+	  }
+	})
+
   octokit.hook.wrap('request', wrapRequest.bind(null, state))
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const BottleneckLight = require('bottleneck/light')
 const wrapRequest = require('./wrap-request')
 const triggersNotificationPaths = require('./triggers-notification-paths')
 const routeMatcher = require('./route-matcher')(triggersNotificationPaths)
+const HttpError = require('./http-error')
 
 // Workaround to allow tests to directly access the triggersNotification function.
 const triggersNotification = throttlingPlugin.triggersNotification =

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,10 +80,6 @@ function throttlingPlugin (octokit, octokitOptions = {}) {
   events.on('error', e => console.warn('Error in throttling-plugin limit handler', e))
 
   state.retryLimiter.on('failed', async function (error, info) {
-    if (error.status !== 403) {
-      return
-    }
-
     const options = info.args[info.args.length - 1]
     const retryCount = ~~options.request.retryCount
     options.request.retryCount = retryCount


### PR DESCRIPTION
Quick attempt to add custom "retryWhen" hook, so we can add more precise conditions when to evaluate error triggers. Useful when adding GraphQL support that returns 200 in case of rete limit and abuse limit errors.

Example usage:

```js
throttle: {
	enabled: true,
	maxConcurrent: 1,
	minTime: 100000,
	// doNotRetry: [200],
	retryWhen: (response, options) => {
		// GraphQL requests return 200 in call cases, this hook captures
		// when it's a retry condition for those
		return isRateLimited(response) || hitAbuseLimits(response)
	},
}
````